### PR TITLE
fix(boot-node): pin relay p2p port so the parachain keeps 30334/ws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.3
+* boot-node: pin the relay p2p port (**ZKV_CONF_PORT=30335**) so the parachain reclaims `/tcp/30334/ws`; the relay was defaulting to parachain port + 1 (30334) and stealing the parachain's ws listener, breaking the ws/wss bootnode endpoints
+
 ## 1.0.2
 * collator-node: add **PARA_CONF_BLOCKS_PRUNING=1000** and **ZKV_CONF_BLOCKS_PRUNING=14400**
 

--- a/env/mainnet/.env.boot-node.template
+++ b/env/mainnet/.env.boot-node.template
@@ -25,6 +25,8 @@ PARA_CONF_LOG="info"
 
 # Node config (Substrate args) - relay chain part
 ZKV_CONF_CHAIN=mainnet
+# Pin the relay p2p port; otherwise it defaults to parachain port + 1 (30334) and steals the parachain's /ws listener
+ZKV_CONF_PORT=30335
 
 # NGINX/ACME config
 NGINX_NET_IP_ADDRESS="10.10.40.11"

--- a/env/testnet/.env.boot-node.template
+++ b/env/testnet/.env.boot-node.template
@@ -25,6 +25,8 @@ PARA_CONF_LOG="info"
 
 # Node config (Substrate args) - relay chain part
 ZKV_CONF_CHAIN=testnet
+# Pin the relay p2p port; otherwise it defaults to parachain port + 1 (30334) and steals the parachain's /ws listener
+ZKV_CONF_PORT=30335
 
 # NGINX/ACME config
 NGINX_NET_IP_ADDRESS="10.10.40.11"


### PR DESCRIPTION
## Problem

On the boot-node profile, the embedded **relay chain** is given no p2p port (only `ZKV_CONF_CHAIN`). Cumulus defaults the relay port to the parachain base port + 1 = **30334**, and it binds a `/ws` listener there before the parachain can:

```
PARA_CONF_LISTEN_ADDR="/ip4/0.0.0.0/tcp/30333,/ip4/0.0.0.0/tcp/30334/ws"
ZKV_CONF_CHAIN=testnet     # no port -> relay defaults onto 30334
```

So the published `30334` port — and the `443/wss` endpoint that `nginx-proxy` proxies to it (`VIRTUAL_PORT=${NODE_NET_P2P_PORT_WS}`) — serve the **relay** chain, not the parachain. Both the `ws` and `wss` bootnode endpoints resolve to the wrong peer ID and are rejected by dialing peers on the libp2p peer-ID check; only raw `tcp/30333` works.

## Fix

Pin the relay to `/tcp/30335` via `ZKV_CONF_PORT` in the testnet + mainnet boot-node templates, so the parachain reclaims `30334/ws`. All three bootnode legs (`tcp/30333`, `ws/30334`, `wss/443`) then resolve to the parachain peer ID. boot-node only — collator/rpc use only 30333 and have no collision. The relay stays on an unpublished port (outbound sync is sufficient for a boot node, so `ports:` is unchanged).

Mirrors the same fix in the internal `compose-vflow` repo (PR #45). No IPv6 change here — this simplified repo is IPv4-only (no v6 network / ipv6nat), so `ENABLE_IPV6` does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)